### PR TITLE
fix perl pinning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,11 @@
 version: 2
 
 jobs:
-  build:
+  build__CONDA_PERL_5.20.3.1:
     working_directory: ~/test
     machine: true
+    environment:
+      - CONDA_PERL: "5.20.3.1"
     steps:
       - checkout
       - run:
@@ -14,6 +16,73 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
+          name: Print conda-build environment variables
+          command: |
+            echo "CONDA_PERL=${CONDA_PERL}"
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./ci_support/run_docker_build.sh
+  build__CONDA_PERL_5.22.0.1:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONDA_PERL: "5.22.0.1"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./ci_support/fast_finish_ci_pr_build.sh
+            ./ci_support/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          name: Print conda-build environment variables
+          command: |
+            echo "CONDA_PERL=${CONDA_PERL}"
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./ci_support/run_docker_build.sh
+  build__CONDA_PERL_5.22.2.1:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONDA_PERL: "5.22.2.1"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./ci_support/fast_finish_ci_pr_build.sh
+            ./ci_support/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          name: Print conda-build environment variables
+          command: |
+            echo "CONDA_PERL=${CONDA_PERL}"
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./ci_support/run_docker_build.sh
+  build__CONDA_PERL_5.26.0:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONDA_PERL: "5.26.0"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./ci_support/fast_finish_ci_pr_build.sh
+            ./ci_support/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          name: Print conda-build environment variables
+          command: |
+            echo "CONDA_PERL=${CONDA_PERL}"
+      - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
 
@@ -21,4 +90,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - build__CONDA_PERL_5.20.3.1
+      - build__CONDA_PERL_5.22.0.1
+      - build__CONDA_PERL_5.22.2.1
+      - build__CONDA_PERL_5.26.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ os: osx
 osx_image: xcode6.4
 
 env:
+  matrix:
+    
+    - CONDA_PERL=5.20.3.1
+    - CONDA_PERL=5.22.0.1
+    - CONDA_PERL=5.22.2.1
+    - CONDA_PERL=5.26.0
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "CymnkLnlNgYMLAuP0wu4gEdvEhcy3Qw4LdtnDPevvciVV7OcKveQpfpBk2GpZBZVBDRDkc3C60+L94vYjtArlRDvS6xcZ09kfaPL4d05MRDcTTkoXbeYAtj/wDiktByKNrEk2y2VXZsLAZ9Ybw6H8G2pnDX18jUb5JThlCy10fB5+aU+6BpixL1FOpZv2CFxPInweYRHwXfAipk2/SsXC4yAUgjja83VySwqnc6zCmWdayqyl9D/noIhskZiHj5DH39buDreHhmJSeLK1Mz8YMSlgAuNLAOuYsKZWTuGqwHlXGwb5lsGrh385U3Is71zTDXz35a/Ljez8XbgNmzzzhc/wi7orPiYSdSQc8HLEVkBRrF7m6uyXprA5HYl9CjcDnzGQhROF7CIi3M6zhAl0ls3VyZ9SH1Sx0VKyZMuZ3zf1m2NymRKPeD1KEVVjBsDAftdaJrTPKH2JOJnytYDHnR8wJDN2uoNBjBL3YvTaq0yQXXcfkz++blznwFqgP9ZtREyew8Nbyn1d/OTZkS7cm9HzBbG0XqnYqIMSjh5C6maDFBqX4+0Zta2iOTQ4hLG09NbDUFW8JykviAXTxsa1ClXSZ+B8VtOcdH2jqc0ZC05G41HdA/F3Um3JgrKm+7uG6WRdNnUfUEDDtQ3yODdc+Dx2IbC98iQj3s73Dle1F4="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -40,6 +40,7 @@ cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -e HOST_USER_ID="${HOST_USER_ID}" \
+                        -e CONDA_PERL="${CONDA_PERL}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ build:
   skip: True  # [win]
 
 requirements:
+  build:
+    - perl
   run:
     - perl
   


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/conda-forge/staged-recipes/pull/4833#issuecomment-359529443.

This was my bad: `perl` is one of the packages that conda automatically pins versions based on, but because it wasn't a build dependency, it only got built once instead of in a matrix. Whoops. :|

(Go ahead and merge this once CircleCI passes rather than waiting for Travis.)